### PR TITLE
Button to open a plugin provided configuration dialog if available

### DIFF
--- a/PluginLoader/Data/PluginData.cs
+++ b/PluginLoader/Data/PluginData.cs
@@ -168,11 +168,11 @@ namespace avaness.PluginLoader.Data
 
         public abstract void Show();
 
-        public bool HasConfiguration => Main.Instance.TryGetPluginInstance(Id, out var pluginInstance) && pluginInstance.HasConfigDialog;
+        public bool HasConfiguration => Main.Instance.TryGetPluginInstance(Id, out PluginInstance pluginInstance) && pluginInstance.HasConfigDialog;
 
         public void Configure()
         {
-            if (!Main.Instance.TryGetPluginInstance(Id, out var pluginInstance))
+            if (!Main.Instance.TryGetPluginInstance(Id, out PluginInstance pluginInstance))
                 return;
 
             if (!pluginInstance.HasConfigDialog)

--- a/PluginLoader/Data/PluginData.cs
+++ b/PluginLoader/Data/PluginData.cs
@@ -168,6 +168,19 @@ namespace avaness.PluginLoader.Data
 
         public abstract void Show();
 
+        public bool HasConfiguration => Main.Instance.TryGetPluginInstance(Id, out var pluginInstance) && pluginInstance.HasConfigDialog;
+
+        public void Configure()
+        {
+            if (!Main.Instance.TryGetPluginInstance(Id, out var pluginInstance))
+                return;
+
+            if (!pluginInstance.HasConfigDialog)
+                return;
+
+            pluginInstance.OpenConfigDialog();
+        }
+
         public void GetDescriptionText(MyGuiControlMultilineText textbox)
         {
             if(string.IsNullOrEmpty(Description))

--- a/PluginLoader/Data/PluginData.cs
+++ b/PluginLoader/Data/PluginData.cs
@@ -168,19 +168,6 @@ namespace avaness.PluginLoader.Data
 
         public abstract void Show();
 
-        public bool HasConfiguration => Main.Instance.TryGetPluginInstance(Id, out PluginInstance pluginInstance) && pluginInstance.HasConfigDialog;
-
-        public void Configure()
-        {
-            if (!Main.Instance.TryGetPluginInstance(Id, out PluginInstance pluginInstance))
-                return;
-
-            if (!pluginInstance.HasConfigDialog)
-                return;
-
-            pluginInstance.OpenConfigDialog();
-        }
-
         public void GetDescriptionText(MyGuiControlMultilineText textbox)
         {
             if(string.IsNullOrEmpty(Description))

--- a/PluginLoader/GUI/PluginDetails.cs
+++ b/PluginLoader/GUI/PluginDetails.cs
@@ -46,6 +46,7 @@ namespace avaness.PluginLoader.GUI
 
         // Plugin currently loaded into the panel or null if none are loaded
         private PluginData plugin;
+        private PluginInstance instance;
 
         private readonly MyGuiScreenPluginConfig pluginsDialog;
 
@@ -63,6 +64,8 @@ namespace avaness.PluginLoader.GUI
                     return;
 
                 plugin = value;
+                if (Main.Instance.TryGetPluginInstance(plugin.Id, out PluginInstance instance))
+                    this.instance = instance;
 
                 if (plugin == null)
                 {
@@ -150,7 +153,7 @@ namespace avaness.PluginLoader.GUI
 
             enableCheckbox.IsChecked = pluginsDialog.AfterRebootEnableFlags[plugin.Id];
 
-            configButton.Enabled = plugin.HasConfiguration;
+            configButton.Enabled = instance != null && instance.HasConfigDialog;
         }
 
         private readonly PluginStat dummyStat = new();
@@ -283,7 +286,7 @@ namespace avaness.PluginLoader.GUI
             };
 
             // Plugin config button
-            configButton = new MyGuiControlButton(onButtonClick: _ => Plugin?.Configure())
+            configButton = new MyGuiControlButton(onButtonClick: _ => instance?.OpenConfig())
             {
                 OriginAlign = MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_TOP,
                 Text = "Plugin Config"

--- a/PluginLoader/GUI/PluginDetails.cs
+++ b/PluginLoader/GUI/PluginDetails.cs
@@ -39,6 +39,7 @@ namespace avaness.PluginLoader.GUI
         private MyGuiControlLabel enableLabel;
         private MyGuiControlCheckbox enableCheckbox;
         private MyGuiControlButton infoButton;
+        private MyGuiControlButton configButton;
 
         // Layout management
         private MyLayoutTable layoutTable;
@@ -148,6 +149,8 @@ namespace avaness.PluginLoader.GUI
             plugin.GetDescriptionText(descriptionText);
 
             enableCheckbox.IsChecked = pluginsDialog.AfterRebootEnableFlags[plugin.Id];
+
+            configButton.Enabled = plugin.HasConfiguration;
         }
 
         private readonly PluginStat dummyStat = new();
@@ -279,6 +282,13 @@ namespace avaness.PluginLoader.GUI
                 Text = "Plugin Info"
             };
 
+            // Plugin config button
+            configButton = new MyGuiControlButton(onButtonClick: _ => Plugin?.Configure())
+            {
+                OriginAlign = MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_TOP,
+                Text = "Plugin Config"
+            };
+
             LayoutControls(rightSideOrigin);
         }
 
@@ -340,7 +350,11 @@ namespace avaness.PluginLoader.GUI
             layoutTable.Add(enableCheckbox, MyAlignH.Left, MyAlignV.Center, row, 1);
             row++;
 
+            const float infoConfigSpacing = 0.015f;
             layoutTable.AddWithSize(infoButton, MyAlignH.Right, MyAlignV.Center, row, 0, 1, colSpan: 2);
+            layoutTable.AddWithSize(configButton, MyAlignH.Right, MyAlignV.Center, row, 0, 1, colSpan: 2);
+            configButton.Position += new Vector2(0f, infoConfigSpacing);
+            infoButton.Position = configButton.Position + new Vector2(-configButton.Size.X - infoConfigSpacing, 0);
             // row++;
 
             var border = 0.002f * Vector2.One;

--- a/PluginLoader/Main.cs
+++ b/PluginLoader/Main.cs
@@ -85,6 +85,24 @@ namespace avaness.PluginLoader
             Splash = null;
         }
 
+        public bool TryGetPluginInstance(string id, out PluginInstance instance)
+        {
+            instance = null;
+            if (!init)
+                return false;
+
+            for (int i = plugins.Count - 1; i >= 0; i--)
+            {
+                var p = plugins[i];
+                if (p.Id == id)
+                {
+                    instance = p;
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         private void ReportEnabledPlugins()
         {

--- a/PluginLoader/Main.cs
+++ b/PluginLoader/Main.cs
@@ -91,9 +91,8 @@ namespace avaness.PluginLoader
             if (!init)
                 return false;
 
-            for (int i = plugins.Count - 1; i >= 0; i--)
+            foreach (PluginInstance p in plugins)
             {
-                PluginInstance p = plugins[i];
                 if (p.Id == id)
                 {
                     instance = p;

--- a/PluginLoader/Main.cs
+++ b/PluginLoader/Main.cs
@@ -93,7 +93,7 @@ namespace avaness.PluginLoader
 
             for (int i = plugins.Count - 1; i >= 0; i--)
             {
-                var p = plugins[i];
+                PluginInstance p = plugins[i];
                 if (p.Id == id)
                 {
                     instance = p;

--- a/PluginLoader/PluginInstance.cs
+++ b/PluginLoader/PluginInstance.cs
@@ -41,7 +41,7 @@ namespace avaness.PluginLoader
                 return false;
             }
 
-            var openConfigDialog = AccessTools.DeclaredMethod(plugin.GetType(), "OpenConfigDialog", Array.Empty<Type>());
+            MethodInfo openConfigDialog = AccessTools.DeclaredMethod(plugin.GetType(), "OpenConfigDialog", Array.Empty<Type>());
             if (openConfigDialog != null)
                 OpenConfigDialog = () => openConfigDialog.Invoke(plugin, Array.Empty<object>());
 


### PR DESCRIPTION
Plugin Config button, invoking the `OpenConfigDialog` method on the plugin's main object if present, otherwise the new button is grayed out.