### PR TITLE
Specify language version

### DIFF
--- a/PluginLoader/Compiler/RoslynCompiler.cs
+++ b/PluginLoader/Compiler/RoslynCompiler.cs
@@ -102,11 +102,11 @@ namespace avaness.PluginLoader.Compiler
                 if (includeText)
                 {
                     Text = EmbeddedText.FromSource(name, source);
-                    Tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest), name);
+                    Tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.CSharp7_3), name);
                 }
                 else
                 {
-                    Tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));
+                    Tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.CSharp7_3));
                 }
             }
         }


### PR DESCRIPTION
Changing the CSharpOptions LanguageVersion from 'Latest' to 'CSharp7_3' adds the TargetFramework assembly attribute to the compiled plugin file specifying that it uses the .Net Framework version 4.8. Not super important, but without that it was causing dnSpy to load the latest .Net Core assemblies when I was trying to debug my plugins, which had weird side-effects. Nothing critical, feel free to ignore this if you want as this issue no longer affects me personally.